### PR TITLE
Add spot market support

### DIFF
--- a/core/src/cgcloud/core/box.py
+++ b/core/src/cgcloud/core/box.py
@@ -388,7 +388,8 @@ class Box( object ):
             # this means we are using a spot bid. We need a couple additional kwargs
             self._check_bid(instance_type, options)
             kwargs['price']=options['price']
-            kwargs['launch_group']='cgcloud_spot_group' # FIXME: ADD IN NAMESPACE
+
+            kwargs['launch_group']=self.ctx.namespace.replace("/","")+"_launch_group"
             try: # There is no min/max count parameter for request_spot_instances, just count
                 kwargs['count']=kwargs['max_count']
                 del kwargs['max_count']
@@ -466,7 +467,7 @@ class Box( object ):
                     log.info("Spot request in status %s. Waiting for 60sec" % (updatedRequest.status.code, ))
                     time.sleep(60)
         finally: # We want to cancel the request if we give up. If the request is fulfilled it doesn't hurt to cancel it either
-            # FIXME: IF THE REQUEST HAS BEEN FULFILLED WE ALSO WANT TO TERMINATE INSTANCES ON ERROR
+            # FIXME: IF THE REQUEST HAS BEEN FULFILLED, DO WE ALSO WANT TO TERMINATE INSTANCES ON ERROR?
             self.ctx.ec2.cancel_spot_instance_requests(request_ids=[updatedRequest.id for updatedRequest in [request for request in requests]])
         return instances
 

--- a/core/src/cgcloud/core/box.py
+++ b/core/src/cgcloud/core/box.py
@@ -8,6 +8,8 @@ import socket
 import subprocess
 import time
 import itertools
+import datetime
+import os
 
 from bd2k.util.collections import OrderedSet
 from boto import logging
@@ -356,6 +358,7 @@ class Box( object ):
             instance_type = self.recommended_instance_type( )
 
         virtualization_types = self.__get_virtualization_types( instance_type, virtualization_type )
+        spot_support = ec2_instance_types[instance_type].spot_availability
         image = self.__get_image( virtualization_types, image_ref )
         security_groups = self.__setup_security_groups( )
 
@@ -373,14 +376,39 @@ class Box( object ):
             raise UserError( "The first key pair name can't be a glob." )
         self.ec2_keypairs = ec2_keypairs
         self.ec2_keypair_globs = ec2_keypair_globs
-
         kwargs = dict( instance_type=instance_type,
                        key_name=ec2_keypairs[ 0 ].name,
                        placement=self.ctx.availability_zone,
                        security_groups=security_groups,
-                       instance_profile_arn=self._get_instance_profile_arn( ) )
+                       instance_profile_arn=self._get_instance_profile_arn( ))
+
         self._populate_instance_creation_args( image, kwargs )
+        if options['price'] != None:
+            assert spot_support is True
+            # this means we are using a spot bid. We need a couple additional kwargs
+            self._check_bid(instance_type, options)
+            kwargs['price']=options['price']
+            kwargs['launch_group']='cgcloud_spot_group' # FIXME: ADD IN NAMESPACE
+            try: # There is no min/max count parameter for request_spot_instances, just count
+                kwargs['count']=kwargs['max_count']
+                del kwargs['max_count']
+                del kwargs['min_count']
+            except KeyError:
+                pass
         self.instance_creation_args = kwargs
+
+    def _check_bid(self, instance_type, options):
+        # Don't allow crazy bids.
+        try:
+            current_time = datetime.datetime.now().isoformat()
+            one_week_ago = (datetime.datetime.now() - datetime.timedelta(days=7)).isoformat()
+            listOfTuple = self.ctx.ec2.get_spot_price_history(start_time=one_week_ago, end_time=current_time, instance_type=instance_type)
+            average = sum([x.price for x in listOfTuple]) / len(listOfTuple)
+            assert (float(options['price']) < (average * 2))
+        except AssertionError as e:
+            log.critical("Your bid $ %f is more than double this instance type's average spot price ($ %f) over the last week"
+                         % (float(options['price']), average))
+            raise e
 
     def create( self, wait_ready=True, cluster_ordinal=0 ):
         """
@@ -394,7 +422,11 @@ class Box( object ):
         :return: the list of clones of this box, if any
         """
         # FIXME: we should be waiting for all instances in parallel, via threads
-        reservation = self._create( )
+        try: #without the price kwarg, _spot_create will fail.
+            reservation = self._create( )
+        except TypeError:
+            reservation = self._spot_create()
+
         instances = iter( sorted( reservation.instances, key=attrgetter( 'id' ) ) )
         cluster_ordinal = itertools.count( start=cluster_ordinal )
         self._bind( next( instances ), next( cluster_ordinal ), wait_ready )
@@ -407,6 +439,22 @@ class Box( object ):
         except StopIteration:
             pass
         return result
+
+    def _spot_create(self):
+        print self.instance_creation_args
+        request = self.ctx.ec2.request_spot_instances(image_id=self.image_id, **self.instance_creation_args)[0]
+        try:
+            while True:
+                request = self.ctx.ec2.get_all_spot_instance_requests(request_ids=[request.id])[0]  # update the one request
+                print request.status.code
+                if request.status.code == 'fulfilled':
+                    reservation = self.ctx.ec2.get_all_instances(request.instance_id)[0]  # just get the one reservation
+                    break
+                log.info("spot instances not up yet. Waiting for 60sec")  # dont hardcode
+                time.sleep(60)
+        finally: # We want to cancel the request if we give up. If the request is fulfilled it doesn't hurt to cancel it either
+            self.ctx.ec2.cancel_spot_instance_requests(request_ids=[request.id])
+        return reservation
 
     def _create( self ):
         """

--- a/core/src/cgcloud/core/box.py
+++ b/core/src/cgcloud/core/box.py
@@ -10,7 +10,6 @@ import subprocess
 import time
 import itertools
 import datetime
-import numpy
 import os
 
 from bd2k.util.collections import OrderedSet
@@ -35,7 +34,9 @@ from cgcloud.lib.util import (UserError,
                               unpack_singleton,
                               camel_to_snake,
                               ec2_keypair_fingerprint,
-                              private_to_public_key)
+                              private_to_public_key,
+                              mean,
+                              std_dev)
 
 log = logging.getLogger( __name__ )
 
@@ -360,7 +361,6 @@ class Box( object ):
             instance_type = self.recommended_instance_type( )
 
         virtualization_types = self.__get_virtualization_types( instance_type, virtualization_type )
-        spot_support = ec2_instance_types[instance_type].spot_availability
         image = self.__get_image( virtualization_types, image_ref )
         security_groups = self.__setup_security_groups( )
 
@@ -382,29 +382,49 @@ class Box( object ):
                        key_name=ec2_keypairs[ 0 ].name,
                        placement=self.ctx.availability_zone,
                        security_groups=security_groups,
-                       instance_profile_arn=self._get_instance_profile_arn( ))
+                       instance_profile_arn=self._get_instance_profile_arn( ) )
 
         self._populate_instance_creation_args( image, kwargs )
         if options['price'] != None:
-            assert spot_support is True
-            # this means we are using a spot bid. We need a couple additional kwargs
-            self._optimize_bid(instance_type, options, kwargs)
-
-            kwargs['price']=options['price']
-
-            kwargs['launch_group']=self.ctx.namespace.replace("/","")+"_launch_group"
-            try: # There is no min/max count parameter for request_spot_instances, just count
-                kwargs['count']=kwargs['max_count']
-                del kwargs['max_count']
-                del kwargs['min_count']
-            except KeyError:
-                pass
+            self._add_spot_instance_creation_args(instance_type, kwargs, options)
         self.instance_creation_args = kwargs
 
-    def _choose_zone(self, bid, spot_data):
-        # returns the zone to put your spot request based on:
-        #    1) zones with prices currently under the bid
-        #    2) zones with the most stable price
+    def _add_spot_instance_creation_args(self, instance_type, kwargs, options):
+        spot_support = ec2_instance_types[instance_type].spot_availability
+        assert spot_support is True
+        # this means we are using a spot bid. We need a couple additional kwargs
+        self._optimize_bid(instance_type, options, kwargs)
+        kwargs['price'] = options['price']
+        kwargs['launch_group'] = self.ctx.namespace.replace("/", "") + "_launch_group"
+        try:  # There is no min/max count parameter for request_spot_instances, just count
+            kwargs['count'] = kwargs['max_count']
+            del kwargs['max_count']
+            del kwargs['min_count']
+        except KeyError:
+            pass
+
+    @staticmethod
+    def _choose_zone(zones, bid, spot_data):
+        """
+        returns the zone to put the spot request based on, in order of priority:
+           1) zones with prices currently under the bid
+           2) zones with the most stable price
+        :return: String representing the name of the selected zone
+
+        >>> from collections import namedtuple
+        >>> FauxHistory = namedtuple("FauxHistory",["price","availability_zone"])
+        >>> ZoneTuple = namedtuple("ZoneTuple", ["name"])
+        >>> zones =[ZoneTuple("us-west-2a"),ZoneTuple("us-west-2b")]
+        >>> spot_data=[FauxHistory(0.1,"us-west-2a"),FauxHistory(0.2,"us-west-2a"),FauxHistory(0.3,"us-west-2b"),FauxHistory(0.6,"us-west-2b")]
+        >>> Box._choose_zone(zones, 0.15, spot_data)
+        'us-west-2a'
+        >>> spot_data=[FauxHistory(0.3,"us-west-2a"),FauxHistory(0.2,"us-west-2a"),FauxHistory(0.1,"us-west-2b"),FauxHistory(0.6,"us-west-2b")]
+        >>> Box._choose_zone(zones, 0.15, spot_data)
+        'us-west-2b'
+        >>> spot_data=[FauxHistory(0.1,"us-west-2a"),FauxHistory(0.7,"us-west-2a"),FauxHistory(0.1,"us-west-2b"),FauxHistory(0.6,"us-west-2b")]
+        >>> Box._choose_zone(zones, 0.15, spot_data)
+        'us-west-2b'
+       """
 
         ZoneTuple = namedtuple("ZoneTuple", ["name","price_deviation"])
         def _sort_zones(bid, spot_data, zones):
@@ -414,14 +434,14 @@ class Box( object ):
             markets_under_bid, markets_over_bid = [], []
             for zone in zones:
                 zlist = filter(lambda spot_history: spot_history.availability_zone == zone.name, spot_data)
-                std_deviation = numpy.std([spot_history.price for spot_history in zlist])
+                std_deviation = std_dev([spot_history.price for spot_history in zlist])
                 # http://stackoverflow.com/a/12135169
-                (markets_over_bid, markets_under_bid)[spot_data[0].price < bid].append(ZoneTuple(zone.name,std_deviation))
+                (markets_over_bid, markets_under_bid)[zlist[0].price < bid].append(ZoneTuple(zone.name,std_deviation))
             # sort each list in place by increasing standard deviation
-            map(lambda list: list.sort(key=lambda zone_tuple:zone_tuple.price_deviation), [markets_over_bid, markets_under_bid])
+            map(lambda list: list.sort(key=attrgetter("price_deviation")), [markets_over_bid, markets_under_bid])
             return markets_under_bid, markets_over_bid
 
-        markets_under_bid, markets_over_bid = _sort_zones(bid, spot_data, self.ctx.ec2.get_all_zones())
+        markets_under_bid, markets_over_bid = _sort_zones(bid, spot_data, zones)
         most_stable_market = markets_under_bid[0].name if markets_under_bid else markets_over_bid[0].name
         return most_stable_market
 
@@ -430,31 +450,45 @@ class Box( object ):
         bid = float(options['price'])
         spot_data = self._get_spot_history(instance_type)
         self._check_bid(bid, spot_data)
-        most_stable_zone = self._choose_zone(bid,spot_data)
+        most_stable_zone = self._choose_zone(self.ctx.ec2.get_all_zones(),bid,spot_data)
         kwargs["placement"]= most_stable_zone
         log.info("Requesting spot instances in zone %s", most_stable_zone)
 
-    def _check_bid(self, bid, spotData):
-        # Don't allow crazy bids.
-        average = numpy.mean([datum.price for datum in spotData])
-        try:
-            assert (bid < (average * 2))
-        except AssertionError as e:
-            log.critical(
-                "Your bid $ %f is more than double this instance type's average spot price ($ %f) over the last week"
-                % (bid, average))
-            raise e
+    @staticmethod
+    def _check_bid(bid, spotData):
+        """
+        Prevents users from potentially overpaying for instances
+        Note: this checks over the whole region, not a particular zone
+        :param bid: Float
+        :param spotData: List of Boto SpotPriceHistory objects
+        :raises UserError if bid is > 2X the spot price's average
+
+        >>> from collections import namedtuple
+        >>> FauxHistory = namedtuple("FauxHistory",["price","availability_zone"])
+        >>> spot_data=[FauxHistory(0.1,"us-west-2a"),FauxHistory(0.2,"us-west-2a"),FauxHistory(0.3,"us-west-2b"),FauxHistory(0.6,"us-west-2b")]
+        >>> Box._check_bid(0.1, spot_data)
+        >>> Box._check_bid(2, spot_data)
+        Traceback (most recent call last):
+        ...
+        UserError: Your bid $ 2.000000 is more than double this instance type's average spot price ($ 0.300000) over the last week
+
+        """
+        average = mean([datum.price for datum in spotData])
+        if bid > (average * 2):
+            raise UserError("Your bid $ %f is more than double this instance type's average "
+                            "spot price ($ %f) over the last week" % (bid, average))
 
     def _get_spot_history(self, instance_type):
         # returns list of 1,000 most recent spot market data points represented as SpotPriceHistory objects
         # Note: The most recent object/data point will be first in the list.
-        current_time = datetime.datetime.now().isoformat()
-        one_week_ago = (datetime.datetime.now() - datetime.timedelta(days=7)).isoformat()
+        now = datetime.datetime.now()
+        current_time = now.isoformat()
+        one_week_ago = (now - datetime.timedelta(days=7)).isoformat()
         # get_spot_price_history returns SpotPriceHistory objects. ignore the methods outdated documentation
         # We specify linux/unix systems since other OSs are more expensive and throw off the estimation
         spotData = self.ctx.ec2.get_spot_price_history(start_time=one_week_ago, end_time=current_time,
                                                        instance_type=instance_type, product_description="Linux/UNIX")
-        spotData.sort(key=lambda spotHistory: spotHistory.timestamp,
+        spotData.sort(key=attrgetter("timestamp"),
                       reverse=True)
         return spotData
 
@@ -505,10 +539,10 @@ class Box( object ):
             for request in requests:
                 while True:
                     # get_all_spot_instances_requests returns a list, even if you request only 1 id like in this case
-                    updatedRequest = self.ctx.ec2.get_all_spot_instance_requests(request_ids=[request.id])[0]
+                    updatedRequest = unpack_singleton(self.ctx.ec2.get_all_spot_instance_requests(request_ids=[request.id]))
                     if updatedRequest.status.code == 'fulfilled':
                         # get_all_instances always returns a list, though we know there is only 1 instance
-                        instances.append(self.ctx.ec2.get_all_instances(updatedRequest.instance_id)[0])
+                        instances.append(unpack_singleton(self.ctx.ec2.get_all_instances(updatedRequest.instance_id)))
                         break
                     # FIXME: REMOVE HARDCODING
                     log.info("Spot request in status %s. Waiting for 60sec" % (updatedRequest.status.code, ))

--- a/core/src/cgcloud/core/commands.py
+++ b/core/src/cgcloud/core/commands.py
@@ -376,9 +376,11 @@ class CreationCommand( RoleCommand ):
 
         self.option( '--spot-bid',
                      default=None,
-                     help="The price you are willing to pay for your instance per hour, in dollars. "
-                          "The default is none, we use on demand instances unless directed otherwise. "
-                          "Warning: some instances are not available on the spot market!")
+                     help="The maximum price to pay for the specified instance type, in dollars "
+                          "per hour. Only bids under 2X the instance type's average price for "
+                          "the past week will be accepted. The default is none, and on demand "
+                          "instances are used unless directed otherwise. Warning: some instance "
+                          "types are not available on the spot market!")
 
         self.begin_mutex( )
 

--- a/core/src/cgcloud/core/commands.py
+++ b/core/src/cgcloud/core/commands.py
@@ -374,6 +374,12 @@ class CreationCommand( RoleCommand ):
                           "on the instance type, but generally speaking, 'hvm' will be used for "
                           "newer instance types." )
 
+        self.option( '--spot-bid',
+                     default=None,
+                     help="The price you are willing to pay for your instance per hour, in dollars. "
+                          "The default is none, we use on demand instances unless directed otherwise. "
+                          "Warning: some instances are not available on the spot market!")
+
         self.begin_mutex( )
 
         self.option( '--terminate', '-T',
@@ -555,7 +561,8 @@ class RecreateCommand( ImageCommandMixin, CreationCommand ):
         super( RecreateCommand, self ).__init__( application, '--boot-image', '-i' )
 
     def instance_options( self, options ):
-        return dict( image_ref=options.boot_image )
+        return dict( image_ref=options.boot_image,
+                     price=options.spot_bid)
 
     def run_on_creation( self, box, options ):
         pass
@@ -587,10 +594,10 @@ class CreateCommand( CreationCommand ):
                      help="Bring the package repository as well as any installed packages up to "
                           "date, i.e. do what on Ubuntu is achieved by doing "
                           "'sudo apt-get update ; sudo apt-get upgrade'." )
-
     def instance_options( self, options ):
         return dict( image_ref=options.boot_image,
-                     enable_agent=not options.no_agent )
+                     enable_agent=not options.no_agent,
+                     price=options.spot_bid)
 
     def run_on_creation( self, box, options ):
         box.setup( upgrade_installed_packages=options.upgrade )

--- a/core/src/cgcloud/core/commands.py
+++ b/core/src/cgcloud/core/commands.py
@@ -429,7 +429,6 @@ class CreationCommand( RoleCommand ):
             if options.terminate is True:
                 box.terminate( )
 
-
 class RegisterKeyCommand( ContextCommand ):
     """
     Upload an OpenSSH public key for future injection into boxes. The public key will be imported
@@ -569,6 +568,63 @@ class RecreateCommand( ImageCommandMixin, CreationCommand ):
     def run_on_creation( self, box, options ):
         pass
 
+class ClusterCommand( RecreateCommand ):
+    def __init__( self, application ):
+        super( ClusterCommand, self ).__init__( application)
+
+        self.option( '--num-slaves', '-s', metavar='NUM',
+                     type=int, default=1,
+                     help='The number of slaves to start.' )
+        # We want --instance-type for the slaves and --master-instance-type for the master and we
+        # want --master-instance-type to default to the value of --instance-type.
+        super( ClusterCommand, self ).option(
+            '--instance-type', '-t', metavar='TYPE', dest='slave_instance_type',
+            default="t2.micro",
+            help='The type of EC2 instance to launch for the slaves, e.g. t2.micro, '
+                 'm3.small, m3.medium, or m3.large etc. ' )
+        self.option( '--master-instance-type', metavar='TYPE', dest='instance_type',
+                     help='The type of EC2 instance to launch for the master, e.g. t2.micro, '
+                          'm3.small, m3.medium, or m3.large etc. The default is the instance type '
+                          'used for the slaves.' )
+        self.option( '--ebs-volume-size', metavar='GB', default=0,
+                     help='The size in GB of an EBS volume to be attached to each node for '
+                          'persistent data such as that backing HDFS. By default HDFS will be '
+                          'backed instance store ( ephemeral) only, or the root volume for '
+                          'instance types that do not offer instance store.' )
+        self.option( '--master-on-demand',dest='master_on_demand', default=None, action='store_true',
+                     help='Use this option to insure that the master instance will be an '
+                          'on demand instance type, even if the spod-bid argument is passed. '
+                          'Using this flag can create a cluster of spot slaves with an on demand '
+                          'master.' )
+
+    def run_on_box( self, options, box ):
+        try:
+            resolve_me = functools.partial( box.ctx.resolve_me, drop_hostname=False )
+            box.prepare( ec2_keypair_globs=map( resolve_me, options.ec2_keypair_names ),
+                         instance_type=options.instance_type,
+                         virtualization_type=options.virtualization_type,
+                         master_on_demand=options.master_on_demand,
+                         **self.instance_options( options ) )
+            box.create( wait_ready=True )
+            self.run_on_creation( box, options )
+        except:
+            if options.terminate is not False:
+                with panic( ):
+                    box.terminate( wait=False )
+            else:
+                raise
+        else:
+            if options.terminate is True:
+                box.terminate( )
+
+    def option( self, *args, **kwargs ):
+        option_name = args[ 0 ]
+        if option_name == 'role':
+            return
+        elif option_name == '--instance-type':
+            # Suppress the instance type option inherited from the parent so we can roll our own
+            return
+        super( ClusterCommand, self ).option( *args, **kwargs )
 
 class CreateCommand( CreationCommand ):
     """

--- a/core/src/cgcloud/core/instance_type.py
+++ b/core/src/cgcloud/core/instance_type.py
@@ -9,7 +9,7 @@ InstanceType = namedtuple( 'InstanceType', [
     'disks', # the number of ephemeral (aka 'instance store') volumes
     'disk_type', # the type of ephemeral volume
     'disk_capacity', # the capacity of each ephemeral volume in GB
-    'spot_availability' # can this instance be used on the spot market?
+    'spot_availability' # can this instance type be used on the spot market?
 ] )
 
 hvm = 'hvm' # hardware virtualization

--- a/core/src/cgcloud/core/instance_type.py
+++ b/core/src/cgcloud/core/instance_type.py
@@ -8,7 +8,8 @@ InstanceType = namedtuple( 'InstanceType', [
     'virtualization_types', # the supported virtualization types, in order of preference
     'disks', # the number of ephemeral (aka 'instance store') volumes
     'disk_type', # the type of ephemeral volume
-    'disk_capacity' # the capacity of each ephemeral volume in GB
+    'disk_capacity', # the capacity of each ephemeral volume in GB
+    'spot_availability' # can this instance be used on the spot market?
 ] )
 
 hvm = 'hvm' # hardware virtualization
@@ -19,73 +20,72 @@ variable_ecu = -1 # variable ecu
 
 _ec2_instance_types = [
     # current generation instance types
-    InstanceType( 't2.micro', 1, variable_ecu, 1, [ hvm ], 0, None, 0 ),
-    InstanceType( 't2.small', 1, variable_ecu, 2, [ hvm ], 0, None, 0 ),
-    InstanceType( 't2.medium', 2, variable_ecu, 4, [ hvm ], 0, None, 0 ),
-    InstanceType( 't2.large', 2, variable_ecu, 8, [ hvm ], 0, None, 0 ),
+    InstanceType( 't2.micro', 1, variable_ecu, 1, [ hvm ], 0, None, 0, False ),
+    InstanceType( 't2.small', 1, variable_ecu, 2, [ hvm ], 0, None, 0, False ),
+    InstanceType( 't2.medium', 2, variable_ecu, 4, [ hvm ], 0, None, 0, False ),
+    InstanceType( 't2.large', 2, variable_ecu, 8, [ hvm ], 0, None, 0, False ),
 
-    InstanceType( 'm3.medium', 1, 3, 3.75, [ hvm, pv ], 1, ssd, 4 ),
-    InstanceType( 'm3.large', 2, 6.5, 7.5, [ hvm, pv ], 1, ssd, 32 ),
-    InstanceType( 'm3.xlarge', 4, 13, 15, [ hvm, pv ], 2, ssd, 40 ),
-    InstanceType( 'm3.2xlarge', 8, 26, 30, [ hvm, pv ], 2, ssd, 80 ),
+    InstanceType( 'm3.medium', 1, 3, 3.75, [ hvm, pv ], 1, ssd, 4, True ),
+    InstanceType( 'm3.large', 2, 6.5, 7.5, [ hvm, pv ], 1, ssd, 32, True ),
+    InstanceType( 'm3.xlarge', 4, 13, 15, [ hvm, pv ], 2, ssd, 40, True ),
+    InstanceType( 'm3.2xlarge', 8, 26, 30, [ hvm, pv ], 2, ssd, 80, True ),
 
-    InstanceType( 'm4.large', 2, 6.5, 8, [ hvm ], 0, None, 0 ),
-    InstanceType( 'm4.xlarge', 4, 13, 16, [ hvm ], 0, None, 0 ),
-    InstanceType( 'm4.2xlarge', 8, 26, 32, [ hvm ], 0, None, 0 ),
-    InstanceType( 'm4.4xlarge', 16, 53.5, 64, [ hvm ], 0, None, 0 ),
-    InstanceType( 'm4.10xlarge', 40, 124.5, 160, [ hvm ], 0, None, 0 ),
+    InstanceType( 'm4.large', 2, 6.5, 8, [ hvm ], 0, None, 0, True ),
+    InstanceType( 'm4.xlarge', 4, 13, 16, [ hvm ], 0, None, 0, True ),
+    InstanceType( 'm4.2xlarge', 8, 26, 32, [ hvm ], 0, None, 0, True ),
+    InstanceType( 'm4.4xlarge', 16, 53.5, 64, [ hvm ], 0, None, 0, True ),
+    InstanceType( 'm4.10xlarge', 40, 124.5, 160, [ hvm ], 0, None, 0, True ),
 
-    InstanceType( 'c4.large', 2, 8, 3.75, [ hvm ], 0, None, 0 ),
-    InstanceType( 'c4.xlarge', 4, 16, 7.5, [ hvm ], 0, None, 0 ),
-    InstanceType( 'c4.2xlarge', 8, 31, 15, [ hvm ], 0, None, 0 ),
-    InstanceType( 'c4.4xlarge', 16, 62, 30, [ hvm ], 0, None, 0 ),
-    InstanceType( 'c4.8xlarge', 36, 132, 60, [ hvm ], 0, None, 0 ),
+    InstanceType( 'c4.large', 2, 8, 3.75, [ hvm ], 0, None, 0, True ),
+    InstanceType( 'c4.xlarge', 4, 16, 7.5, [ hvm ], 0, None, 0, True ),
+    InstanceType( 'c4.2xlarge', 8, 31, 15, [ hvm ], 0, None, 0, True ),
+    InstanceType( 'c4.4xlarge', 16, 62, 30, [ hvm ], 0, None, 0, True ),
+    InstanceType( 'c4.8xlarge', 36, 132, 60, [ hvm ], 0, None, 0, True ),
 
-    InstanceType( 'c3.large', 2, 7, 3.75, [ hvm, pv ], 2, ssd, 16 ),
-    InstanceType( 'c3.xlarge', 4, 14, 7.5, [ hvm, pv ], 2, ssd, 40 ),
-    InstanceType( 'c3.2xlarge', 8, 28, 15, [ hvm, pv ], 2, ssd, 80 ),
-    InstanceType( 'c3.4xlarge', 16, 55, 30, [ hvm, pv ], 2, ssd, 160 ),
-    InstanceType( 'c3.8xlarge', 32, 108, 60, [ hvm, pv ], 2, ssd, 320 ),
+    InstanceType( 'c3.large', 2, 7, 3.75, [ hvm, pv ], 2, ssd, 16, True ),
+    InstanceType( 'c3.xlarge', 4, 14, 7.5, [ hvm, pv ], 2, ssd, 40, True ),
+    InstanceType( 'c3.2xlarge', 8, 28, 15, [ hvm, pv ], 2, ssd, 80, True ),
+    InstanceType( 'c3.4xlarge', 16, 55, 30, [ hvm, pv ], 2, ssd, 160, True ),
+    InstanceType( 'c3.8xlarge', 32, 108, 60, [ hvm, pv ], 2, ssd, 320, True ),
 
-    InstanceType( 'g2.2xlarge', 8, 26, 15, [ hvm ], 1, ssd, 60 ),
+    InstanceType( 'g2.2xlarge', 8, 26, 15, [ hvm ], 1, ssd, 60, True ),
 
-    InstanceType( 'r3.large', 2, 6.5, 15, [ hvm ], 1, ssd, 32 ),
-    InstanceType( 'r3.xlarge', 4, 13, 30.5, [ hvm ], 1, ssd, 80 ),
-    InstanceType( 'r3.2xlarge', 8, 26, 61, [ hvm ], 1, ssd, 160 ),
-    InstanceType( 'r3.4xlarge', 16, 52, 122, [ hvm ], 1, ssd, 320 ),
-    InstanceType( 'r3.8xlarge', 32, 104, 244, [ hvm ], 2, ssd, 320 ),
+    InstanceType( 'r3.large', 2, 6.5, 15, [ hvm ], 1, ssd, 32, True ),
+    InstanceType( 'r3.xlarge', 4, 13, 30.5, [ hvm ], 1, ssd, 80, True ),
+    InstanceType( 'r3.2xlarge', 8, 26, 61, [ hvm ], 1, ssd, 160, True ),
+    InstanceType( 'r3.4xlarge', 16, 52, 122, [ hvm ], 1, ssd, 320, True ),
+    InstanceType( 'r3.8xlarge', 32, 104, 244, [ hvm ], 2, ssd, 320, True ),
 
-    InstanceType( 'i2.xlarge', 4, 14, 30.5, [ hvm ], 1, ssd, 800 ),
-    InstanceType( 'i2.2xlarge', 8, 27, 61, [ hvm ], 2, ssd, 800 ),
-    InstanceType( 'i2.4xlarge', 16, 53, 122, [ hvm ], 4, ssd, 800 ),
-    InstanceType( 'i2.8xlarge', 32, 104, 244, [ hvm ], 8, ssd, 800 ),
+    InstanceType( 'i2.xlarge', 4, 14, 30.5, [ hvm ], 1, ssd, 800, False ),
+    InstanceType( 'i2.2xlarge', 8, 27, 61, [ hvm ], 2, ssd, 800, False ),
+    InstanceType( 'i2.4xlarge', 16, 53, 122, [ hvm ], 4, ssd, 800, False ),
+    InstanceType( 'i2.8xlarge', 32, 104, 244, [ hvm ], 8, ssd, 800, False ),
 
-    InstanceType( 'd2.xlarge', 4, 14, 30.5, [ hvm ], 3, hdd, 2000 ),
-    InstanceType( 'd2.2xlarge', 8, 28, 61, [ hvm ], 6, hdd, 2000 ),
-    InstanceType( 'd2.4xlarge', 16, 56, 122, [ hvm ], 12, hdd, 2000 ),
-    InstanceType( 'd2.8xlarge', 36, 116, 244, [ hvm ], 24, hdd, 2000 ),
+    InstanceType( 'd2.xlarge', 4, 14, 30.5, [ hvm ], 3, hdd, 2000, True ),
+    InstanceType( 'd2.2xlarge', 8, 28, 61, [ hvm ], 6, hdd, 2000, True ),
+    InstanceType( 'd2.4xlarge', 16, 56, 122, [ hvm ], 12, hdd, 2000, True ),
+    InstanceType( 'd2.8xlarge', 36, 116, 244, [ hvm ], 24, hdd, 2000, True ),
 
     # previous generation instance types
-    InstanceType( 'm1.small', 1, 1, 1.7, [ pv ], 1, hdd, 160 ),
-    InstanceType( 'm1.medium', 1, 2, 3.75, [ pv ], 1, hdd, 410 ),
-    InstanceType( 'm1.large', 2, 4, 7.5, [ pv ], 2, hdd, 420 ),
-    InstanceType( 'm1.xlarge', 4, 8, 15, [ pv ], 4, hdd, 420 ),
+    InstanceType( 'm1.small', 1, 1, 1.7, [ pv ], 1, hdd, 160, True ),
+    InstanceType( 'm1.medium', 1, 2, 3.75, [ pv ], 1, hdd, 410, True ),
+    InstanceType( 'm1.large', 2, 4, 7.5, [ pv ], 2, hdd, 420, True ),
+    InstanceType( 'm1.xlarge', 4, 8, 15, [ pv ], 4, hdd, 420, True ),
 
-    InstanceType( 'c1.medium', 2, 5, 1.7, [ pv ], 1, hdd, 350 ),
-    InstanceType( 'c1.xlarge', 8, 20, 7, [ pv ], 4, hdd, 420 ),
+    InstanceType( 'c1.medium', 2, 5, 1.7, [ pv ], 1, hdd, 350, True ),
+    InstanceType( 'c1.xlarge', 8, 20, 7, [ pv ], 4, hdd, 420, True ),
 
-    InstanceType( 'cc2.8xlarge', 32, 88, 60.5, [ hvm ], 4, hdd, 840 ),
+    InstanceType( 'cc2.8xlarge', 32, 88, 60.5, [ hvm ], 4, hdd, 840, True ),
 
-    InstanceType( 'm2.xlarge', 2, 6.5, 17.1, [ pv ], 1, hdd, 420 ),
-    InstanceType( 'm2.2xlarge', 4, 13, 34.2, [ pv ], 1, hdd, 850 ),
-    InstanceType( 'm2.4xlarge', 8, 26, 68.4, [ pv ], 2, hdd, 840 ),
+    InstanceType( 'm2.xlarge', 2, 6.5, 17.1, [ pv ], 1, hdd, 420, True ),
+    InstanceType( 'm2.2xlarge', 4, 13, 34.2, [ pv ], 1, hdd, 850, True),
+    InstanceType( 'm2.4xlarge', 8, 26, 68.4, [ pv ], 2, hdd, 840, True ),
 
-    InstanceType( 'cr1.8xlarge', 32, 88, 244, [ hvm ], 2, ssd, 120 ),
+    InstanceType( 'cr1.8xlarge', 32, 88, 244, [ hvm ], 2, ssd, 120, True ),
 
-    InstanceType( 'hi1.4xlarge', 16, 35, 60.5, [ hvm, pv ], 2, ssd, 1024 ),
+    InstanceType( 'hi1.4xlarge', 16, 35, 60.5, [ hvm, pv ], 2, ssd, 1024, True ),
+    InstanceType( 'hs1.8xlarge', 16, 35, 117, [ hvm, pv ], 24, hdd, 2048, False ),
 
-    InstanceType( 'hs1.8xlarge', 16, 35, 117, [ hvm, pv ], 24, hdd, 2048 ),
-
-    InstanceType( 't1.micro', 1, variable_ecu, 0.615, [ pv ], 0, None, 0 ) ]
+    InstanceType( 't1.micro', 1, variable_ecu, 0.615, [ pv ], 0, None, 0, True ) ]
 
 ec2_instance_types = dict( ( _.name, _ ) for _ in _ec2_instance_types )

--- a/lib/src/cgcloud/lib/util.py
+++ b/lib/src/cgcloud/lib/util.py
@@ -49,6 +49,56 @@ def unpack_singleton( singleton ):
     except StopIteration:
         return result
 
+def mean(listOfNums):
+    """
+    from http://rosettacode.org/wiki/Standard_deviation#Python
+    :param listOfNums:
+    :return: Floating point representation of the average of listOfNums
+
+    >>> mean([2,4,4,4,5,5,7,9])
+    5.0
+    >>> mean([9,10,11,7,13])
+    10.0
+    >>> mean([1,1,10,19,19])
+    10.0
+    >>> mean([10,10,10,10,10])
+    10.0
+    >>> mean(["a","b"])
+    Traceback (most recent call last):
+      ...
+    TypeError: unsupported operand type(s) for /: 'str' and 'float'
+    >>> mean([])
+    Traceback (most recent call last):
+      ...
+    TypeError: reduce() of empty sequence with no initial value
+    """
+    return (lambda MyList : reduce(lambda x, y: x + y, MyList) / float(len(MyList)))(listOfNums)
+
+def std_dev(listOfNums):
+    """
+    from http://rosettacode.org/wiki/Standard_deviation#Python
+    An empty list, or list of non-numbers, will throw a TypeError
+    :param listOfNums:
+    :return: Floating point representation of the standard deviation of listOfNums
+
+    >>> std_dev([2,4,4,4,5,5,7,9])
+    2.0
+    >>> std_dev([9,10,11,7,13])
+    2.0
+    >>> std_dev([1,1,10,19,19])
+    8.049844718999243
+    >>> std_dev([10,10,10,10,10])
+    0.0
+    >>> std_dev(["a","b"])
+    Traceback (most recent call last):
+      ...
+    TypeError: unsupported operand type(s) for /: 'str' and 'float'
+    >>> std_dev([])
+    Traceback (most recent call last):
+      ...
+    TypeError: reduce() of empty sequence with no initial value
+    """
+    return (lambda MyList : (reduce(lambda x,y : x + y , map(lambda x: (x-mean(MyList))**2 , MyList)) / float(len(MyList)))**.5)(listOfNums)
 
 def camel_to_snake( s, separator='_' ):
     """

--- a/mesos/src/cgcloud/mesos/mesos_box.py
+++ b/mesos/src/cgcloud/mesos/mesos_box.py
@@ -275,7 +275,10 @@ class MesosMaster(MesosBox):
     def prepare( self, *args, **kwargs ):
         # Stash away arguments to prepare() so we can use them when cloning the slaves
         self.preparation_args = args
-        self.preparation_kwargs = kwargs
+        self.preparation_kwargs = dict(kwargs)
+        # the price kwarg determines if the spot market will be used - with master_on_demand we only want spot workers
+        if kwargs["master_on_demand"]:
+            kwargs["price"]=None
         return super( MesosBox, self ).prepare( *args, **kwargs )
 
     def _post_install_packages( self ):
@@ -294,6 +297,7 @@ class MesosMaster(MesosBox):
         args = master.preparation_args
         kwargs = master.preparation_kwargs.copy( )
         kwargs[ 'instance_type' ] = slave_instance_type
+        print kwargs
         first_slave.prepare( *args, **kwargs )
         other_slaves = first_slave.create( wait_ready=False,
                                            cluster_ordinal=master.cluster_ordinal + 1)

--- a/mesos/src/cgcloud/mesos/mesos_box.py
+++ b/mesos/src/cgcloud/mesos/mesos_box.py
@@ -297,7 +297,6 @@ class MesosMaster(MesosBox):
         args = master.preparation_args
         kwargs = master.preparation_kwargs.copy( )
         kwargs[ 'instance_type' ] = slave_instance_type
-        print kwargs
         first_slave.prepare( *args, **kwargs )
         other_slaves = first_slave.create( wait_ready=False,
                                            cluster_ordinal=master.cluster_ordinal + 1)

--- a/mesos/src/cgcloud/mesos/mesos_cluster.py
+++ b/mesos/src/cgcloud/mesos/mesos_cluster.py
@@ -1,12 +1,13 @@
 import logging
 
-from cgcloud.core.commands import RecreateCommand
-from cgcloud.mesos.mesos_box import MesosBox, MesosMaster
+from cgcloud.core import ClusterCommand
+from cgcloud.mesos import MesosBox
+from cgcloud.mesos.mesos_box import MesosMaster
 
 log = logging.getLogger( __name__ )
 
 
-class CreateMesosCluster( RecreateCommand ):
+class CreateMesosCluster( ClusterCommand ):
     """
     Start a cluster of mesos-box instances, by recreating the master from a mesos-box image
     first, then cloning the master into the slaves.
@@ -14,25 +15,7 @@ class CreateMesosCluster( RecreateCommand ):
 
     def __init__( self, application ):
         super( CreateMesosCluster, self ).__init__( application )
-        self.option( '--num-slaves', '-s', metavar='NUM',
-                     type=int, default=1,
-                     help='The number of slaves to start.' )
-        # We want --instance-type for the slaves and --master-instance-type for the master and we
-        # want --master-instance-type to default to the value of --instance-type.
-        super( CreateMesosCluster, self ).option(
-            '--instance-type', '-t', metavar='TYPE', dest='slave_instance_type',
-            default=MesosBox.recommended_instance_type( ),
-            help='The type of EC2 instance to launch for the slaves, e.g. t2.micro, '
-                 'm3.small, m3.medium, or m3.large etc. ' )
-        self.option( '--master-instance-type', metavar='TYPE', dest='instance_type',
-                     help='The type of EC2 instance to launch for the master, e.g. t2.micro, '
-                          'm3.small, m3.medium, or m3.large etc. The default is the instance type '
-                          'used for the slaves.' )
-        self.option( '--ebs-volume-size', metavar='GB', default=0,
-                     help='The size in GB of an EBS volume to be attached to each node for '
-                          'persistent data such as that backing HDFS. By default HDFS will be '
-                          'backed instance store ( ephemeral) only, or the root volume for '
-                          'instance types that do not offer instance store.' )
+
 
     def run_in_ctx( self, options, ctx ):
         """
@@ -52,13 +35,3 @@ class CreateMesosCluster( RecreateCommand ):
         master.clone( num_slaves=options.num_slaves,
                       slave_instance_type=options.slave_instance_type,
                       ebs_volume_size=options.ebs_volume_size )
-
-    def option( self, *args, **kwargs ):
-        option_name = args[ 0 ]
-        if option_name == 'role':
-            return
-        elif option_name == '--instance-type':
-            # Suppress the instance type option inherited from the parent so we can roll our own
-            return
-        super( CreateMesosCluster, self ).option( *args, **kwargs )
-

--- a/mesos/src/cgcloud/mesos/mesos_cluster.py
+++ b/mesos/src/cgcloud/mesos/mesos_cluster.py
@@ -1,7 +1,6 @@
 import logging
 
-from cgcloud.core import ClusterCommand
-from cgcloud.mesos import MesosBox
+from cgcloud.core.commands import ClusterCommand
 from cgcloud.mesos.mesos_box import MesosMaster
 
 log = logging.getLogger( __name__ )

--- a/spark/src/cgcloud/spark/spark_box.py
+++ b/spark/src/cgcloud/spark/spark_box.py
@@ -490,7 +490,10 @@ class SparkMaster( SparkBox ):
     def prepare( self, *args, **kwargs ):
         # Stash awat arguments to prepare() so we can use them when cloning the slaves
         self.preparation_args = args
-        self.preparation_kwargs = kwargs
+        self.preparation_kwargs = dict(kwargs)
+        # the price kwarg determines if the spot market will be used - with master_on_demand we only want spot workers
+        if kwargs["master_on_demand"]:
+            kwargs["price"]=None
         return super( SparkBox, self ).prepare( *args, **kwargs )
 
     def _populate_instance_tags( self, tags_dict ):

--- a/spark/src/cgcloud/spark/spark_cluster.py
+++ b/spark/src/cgcloud/spark/spark_cluster.py
@@ -1,12 +1,13 @@
 import logging
 
-from cgcloud.core.commands import RecreateCommand
-from cgcloud.spark.spark_box import SparkBox, SparkMaster
+from cgcloud.core import ClusterCommand
+from cgcloud.spark import SparkBox
+from cgcloud.spark.spark_box import SparkMaster
 
 log = logging.getLogger( __name__ )
 
 
-class CreateSparkCluster( RecreateCommand ):
+class CreateSparkCluster( ClusterCommand ):
     """
     Start a cluster of spark-box instances, by recreating the master from a spark-box image
     first, then cloning the master into the slaves.
@@ -14,25 +15,6 @@ class CreateSparkCluster( RecreateCommand ):
 
     def __init__( self, application ):
         super( CreateSparkCluster, self ).__init__( application )
-        self.option( '--num-slaves', '-s', metavar='NUM',
-                     type=int, default=1,
-                     help='The number of slaves to start.' )
-        # We want --instance-type for the slaves and --master-instance-type for the master and we
-        # want --master-instance-type to default to the value of --instance-type.
-        super( CreateSparkCluster, self ).option(
-            '--instance-type', '-t', metavar='TYPE', dest='slave_instance_type',
-            default=SparkBox.recommended_instance_type( ),
-            help='The type of EC2 instance to launch for the slaves, e.g. t2.micro, '
-                 'm3.small, m3.medium, or m3.large etc. ' )
-        self.option( '--master-instance-type', metavar='TYPE', dest='instance_type',
-                     help='The type of EC2 instance to launch for the master, e.g. t2.micro, '
-                          'm3.small, m3.medium, or m3.large etc. The default is the instance type '
-                          'used for the slaves.' )
-        self.option( '--ebs-volume-size', metavar='GB', default=0,
-                     help='The size in GB of an EBS volume to be attached to each node for '
-                          'persistent data such as that backing HDFS. By default HDFS will be '
-                          'backed instance store ( ephemeral) only, or the root volume for '
-                          'instance types that do not offer instance store.' )
 
     def run_in_ctx( self, options, ctx ):
         """
@@ -52,13 +34,3 @@ class CreateSparkCluster( RecreateCommand ):
         master.clone( num_slaves=options.num_slaves,
                       slave_instance_type=options.slave_instance_type,
                       ebs_volume_size=options.ebs_volume_size )
-
-    def option( self, *args, **kwargs ):
-        option_name = args[ 0 ]
-        if option_name == 'role':
-            return
-        elif option_name == '--instance-type':
-            # Suppress the instance type option inherited from the parent so we can roll our own
-            return
-        super( CreateSparkCluster, self ).option( *args, **kwargs )
-

--- a/spark/src/cgcloud/spark/spark_cluster.py
+++ b/spark/src/cgcloud/spark/spark_cluster.py
@@ -1,7 +1,6 @@
 import logging
 
-from cgcloud.core import ClusterCommand
-from cgcloud.spark import SparkBox
+from cgcloud.core.commands import ClusterCommand
 from cgcloud.spark.spark_box import SparkMaster
 
 log = logging.getLogger( __name__ )

--- a/toil/src/cgcloud/toil/toil_cluster.py
+++ b/toil/src/cgcloud/toil/toil_cluster.py
@@ -1,13 +1,13 @@
 import logging
-
-from cgcloud.toil.toil_box import ToilLeader
+from cgcloud.toil.toil_box import ToilBox, ToilLeader
+from cgcloud.core import ClusterCommand
 from cgcloud.mesos.mesos_cluster import CreateMesosCluster
 
 log = logging.getLogger( __name__ )
-shared_dir = "/home/mesosbox/shared/"
+shared_dir="/home/mesosbox/shared/"
 
 
-class CreateToilCluster( CreateMesosCluster ):
+class CreateToilCluster(ClusterCommand):
     def __init__( self, application ):
         super( CreateToilCluster, self ).__init__( application )
         self.option( '--shared-dir', default=None,
@@ -19,12 +19,12 @@ class CreateToilCluster( CreateMesosCluster ):
         """
         dir = options.shared_dir
         if dir:
-            log.info( "Rsyncing selected directory to master" )
+            log.info("Rsyncing selected directory to master")
             master.rsync( args=[ '-r', dir, ":" + shared_dir ] )
         log.info( "=== Launching workers ===" )
         master.clone( num_slaves=options.num_slaves,
                       slave_instance_type=options.slave_instance_type,
-                      ebs_volume_size=options.ebs_volume_size )
+                      ebs_volume_size=options.ebs_volume_size)
 
     def run_in_ctx( self, options, ctx ):
         """
@@ -33,4 +33,4 @@ class CreateToilCluster( CreateMesosCluster ):
         log.info( "=== Launching leader ===" )
         if options.instance_type is None:
             options.instance_type = options.slave_instance_type
-        return self.run_on_box( options, ToilLeader( ctx ) )
+        return self.run_on_box( options, ToilLeader( ctx) )

--- a/toil/src/cgcloud/toil/toil_cluster.py
+++ b/toil/src/cgcloud/toil/toil_cluster.py
@@ -1,7 +1,6 @@
 import logging
-from cgcloud.toil.toil_box import ToilBox, ToilLeader
-from cgcloud.core import ClusterCommand
-from cgcloud.mesos.mesos_cluster import CreateMesosCluster
+from cgcloud.toil.toil_box import ToilLeader
+from cgcloud.core.commands import ClusterCommand
 
 log = logging.getLogger( __name__ )
 shared_dir="/home/mesosbox/shared/"


### PR DESCRIPTION
Added flag --spot-bid to Creation Command class. Makes sure the bid is reasonable by averaging the last week's spot price for the requested instance, and insuring that the bid less than double that average. Checks that the instance you request is available on the spot market. Works with any command that inherits from CreationCommand including create, recreate, and create-mesos-cluster. 
