### PR TITLE
Report memory and disk usage metrics via agent to CloudWatch (resolves #87)

### DIFF
--- a/agent/setup.py
+++ b/agent/setup.py
@@ -28,4 +28,5 @@ setup(
         'cgcloud-lib==' + cgcloud_version,
         'boto==' + boto_version,
         'python-daemon==2.0.6',
-        'argparse==1.4.0' if sys.version_info < (2, 7) else None ] ) )
+        'argparse==1.4.0' if sys.version_info < (2, 7) else None,
+        'psutil>=2.2.1'] ) )

--- a/core/src/cgcloud/core/agent_box.py
+++ b/core/src/cgcloud/core/agent_box.py
@@ -144,7 +144,12 @@ class AgentBox( PackageManagerBox, AbstractInitBox ):
                         "sns:Get*",
                         "sns:List*",
                         "sns:CreateTopic",
-                        "sns:Subscribe" ] ) ] ) ) )
+                        "sns:Subscribe"] ) ] ),
+                cloud_watch=dict( Version='2012-10-17', Statement=[
+                    dict( Effect='Allow', Resource='*', Action=[
+                        'cloudwatch:Get*',
+                        'cloudwatch:List*',
+                        'cloudwatch:PutMetricData'] ) ] ) ) )
         return role_name, policies
 
     @staticmethod


### PR DESCRIPTION
Thread added to agent that collects disk and memory every 5 minutes and
creates/updates those cloudwatch values for a given instance.

Tested using the `stress` command line tool and an aggregate metric collection script I wrote. 

Pinging @hannes-ucsc for review and suggestions. 
