### PR TITLE
Fix /etc/init/docker.conf patch for Docker 1.10

### DIFF
--- a/toil/src/cgcloud/toil/toil_box.py
+++ b/toil/src/cgcloud/toil/toil_box.py
@@ -50,8 +50,8 @@ class ToilBox( MesosBoxSupport, DockerBox, ClusterBox ):
                 @@ -1,6 +1,6 @@
                  description "Docker daemon"
 
-                -start on (local-filesystems and net-device-up IFACE!=lo)
-                +start on (local-filesystems and net-device-up IFACE!=lo and started mesosbox)
+                -start on (filesystem and net-device-up IFACE!=lo)
+                +start on (filesystem and net-device-up IFACE!=lo and started mesosbox)
                  stop on runlevel [!2345]
                  limit nofile 524288 1048576
                  limit nproc 524288 1048576""" ) )


### PR DESCRIPTION
In docker 1.10, the Upstart docker.conf script has been changed slightly, making the patch fail in toil box.  

Docker 1.10: https://github.com/docker/docker/blob/master/contrib/init/upstart/docker.conf

Docker 1.9.1: https://github.com/docker/docker/blob/v1.9.1/contrib/init/upstart/docker.conf

I don't know whether you should actually merge this or not, since you're considering pinning Docker at 1.9.1. 
