### PR TITLE
Setup TOIL_WORKDIR on toil boxes (resolves #102)

### DIFF
--- a/toil/src/cgcloud/toil/test/test_toil.py
+++ b/toil/src/cgcloud/toil/test/test_toil.py
@@ -88,8 +88,10 @@ class ToilClusterTests( MesosTestCase ):
             # noinspection PyUnresolvedReferences
             from toil.job import Job
             from subprocess import check_output
+            import os
 
             def hello( name ):
+                assert os.environ['TOIL_WORKDIR'] == '/var/lib/toil'
                 return check_output( [ 'docker', 'run', '-e', 'FOO=' + name, 'ubuntu',
                                          'bash', '-c', 'echo -n Hello, $FOO!' ] )
 

--- a/toil/src/cgcloud/toil/toil_box.py
+++ b/toil/src/cgcloud/toil/toil_box.py
@@ -7,7 +7,7 @@ from cgcloud.core.box import fabric_task
 from cgcloud.core.cluster import ClusterBox, ClusterWorker, ClusterLeader
 from cgcloud.core.common_iam_policies import ec2_full_policy, s3_full_policy, sdb_full_policy
 from cgcloud.core.docker_box import DockerBox
-from cgcloud.fabric.operations import pip, remote_sudo_popen
+from cgcloud.fabric.operations import pip, remote_sudo_popen, sudo
 from cgcloud.lib.util import abreviated_snake_case_class_name, heredoc
 from cgcloud.mesos.mesos_box import MesosBoxSupport, user, persistent_dir
 
@@ -88,6 +88,8 @@ class ToilBox( MesosBoxSupport, DockerBox, ClusterBox ):
         pip( 'install --pre s3am', use_sudo=True )
         pip( concat( 'install', self._toil_pip_args( ) ), use_sudo=True )
         self._lazy_mkdir( '/var/lib', 'toil', persistent=None )
+        # setup the env variable TOIL_WORKDIR. Write to /etc/environ so it persists
+        sudo('echo "TOIL_WORKDIR=/var/lib/toil" >> /etc/environment')
 
     def _toil_pip_args( self ):
         return [ 'toil[aws,mesos,encryption]==3.1.3' ]


### PR DESCRIPTION
Resolves #102 
Environment variable TOIL_WORKDIR is set to /var/lib/toil and written to /etc/environment so it persists.
