### PR TITLE
mesos-box: Setup mesos credentials (resolves #103)

### DIFF
--- a/mesos/src/cgcloud/mesos/mesos_box.py
+++ b/mesos/src/cgcloud/mesos/mesos_box.py
@@ -48,7 +48,8 @@ mesos_services = dict(
                             '--registry=in_memory',
                             # would use "--ip mesos-master" here but that option only supports
                             # IP addresses, not DNS names or /etc/hosts entries
-                            '--ip_discovery_command="hostname -i"' ) ],
+                            '--ip_discovery_command="hostname -i"',
+                            '--credentials=/etc/mesos/credentials') ],
     slave=[ mesos_service( 'slave',
                            '--master=mesos-master:5050',
                            '--no-switch_user',
@@ -157,11 +158,18 @@ class MesosBoxSupport( GenericUbuntuTrustyBox, Python27UpdateUbuntuBox, CoreMeso
         sudo( "rm /etc/init/mesos-{master,slave}.conf" )
         self._lazy_mkdir( log_dir, 'mesos', persistent=False )
         self._lazy_mkdir( '/var/lib', 'mesos', persistent=True )
+        self.__prepare_credentials( )
         self.__register_upstart_jobs( mesos_services )
         self._post_install_mesos( )
 
     def _post_install_mesos( self ):
         pass
+
+    def __prepare_credentials(self):
+        # Create the credentials file and transfer ownership to mesosbox
+        sudo('mkdir -p /etc/mesos')
+        sudo('echo toil liot > /etc/mesos/credentials')
+        sudo('chown mesosbox:mesosbox /etc/mesos/credentials')
 
     @fabric_task
     def __install_tools( self ):


### PR DESCRIPTION
1. Mesosboxes now use Mesos version 0.27.0
2. The Master on a toil cluster now accepts authenticated http requests from slaves
3. Credentials are setup on the box when the mesosbox service is started
4. Setup a TMPDIR env variable on toil-jenkins-slaves such that all tests will now occur on the (larger) ephemeral disk.

Resolves #103 and is related to https://github.com/BD2KGenomics/toil/issues/681
