### PR TITLE
Increased executor shutdown grace period (resolves #111)

### DIFF
--- a/mesos/src/cgcloud/mesos/mesos_box.py
+++ b/mesos/src/cgcloud/mesos/mesos_box.py
@@ -53,6 +53,7 @@ mesos_services = dict(
                            '--master=mesos-master:5050',
                            '--no-switch_user',
                            '--work_dir=' + work_dir,
+                           '--executor_shutdown_grace_period=60secs',
                            '$(cat /var/lib/mesos/slave_args)' ) ] )
 
 


### PR DESCRIPTION
When the framework asks the executor to shutdown, the slave waits 5s (default) for the executor to shut down before forcefully killing it. Increasing the value allows for more time to conduct user-defined cleanup jobs once the executor is asked to shutdown.
1. New shutdown period is 60 seconds.

(Resolves #111)
