### PR TITLE
Update toil-jenkins-slave (resolves #114, resolves #116)

### DIFF
--- a/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
+++ b/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
@@ -48,7 +48,15 @@ class ToilJenkinsSlave( UbuntuTrustyGenericJenkinsSlave,
         self.__install_parasol( )
         self.__patch_distutils( )
         self.__configure_gridengine( )
+        self.__createMesosCredentialsFile( )
 
+    @fabric_task
+    def __createMesosCredentialsFile(self):
+        # Create the credentials file and transfer ownership to mesosbox
+        sudo( 'echo toil liot > /var/lib/mesos/credentials.txt' )
+        sudo( 'chown jenkins:jenkins /var/lib/mesos/credentials.txt')
+        sudo( 'chmod 755 /var/lib/mesos/credentials.txt')
+        
     @fabric_task
     def __disable_mesos_daemons( self ):
         for daemon in ('master', 'slave'):

--- a/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
+++ b/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
@@ -56,7 +56,7 @@ class ToilJenkinsSlave( UbuntuTrustyGenericJenkinsSlave,
 
     @fabric_task
     def __install_parasol( self ):
-        run( "git clone git@github.com:BD2KGenomics/parasol-binaries.git" )
+        run( "git clone https://github.com/BD2KGenomics/parasol-binaries.git" )
         sudo( "cp parasol-binaries/* /usr/local/bin" )
         run( "rm -rf parasol-binaries" )
 


### PR DESCRIPTION
Resolves #114, resolves #116, related to #103
1. Some toil tests need a mesos credentials file to run. Credentials are now created when the box is first created. credentials reside at `/var/lib/mesos/credentials.txt` this is on the root volume hence it should persist if an image is created and new slaves are created off it.
2. parasol binaries downloaded from git were dependent on the public key of the box being registered with the BD2KGenomics git repo, or the creating user having ssh agent forwarding set up. Modified the git clone step to use http cloning that does not have these requirements.
