### PR TITLE
Add ability to specify custom /etc/hosts entries for Spark, Mesos and Toil nodes (resolves #119)

### DIFF
--- a/mesos/src/cgcloud/mesos/mesos_box.py
+++ b/mesos/src/cgcloud/mesos/mesos_box.py
@@ -64,6 +64,16 @@ class MesosBoxSupport( GenericUbuntuTrustyBox, Python27UpdateUbuntuBox, CoreMeso
     and port before starting up.
     """
 
+    @classmethod
+    def get_role_options( cls ):
+        return super( MesosBoxSupport, cls ).get_role_options( ) + [
+            cls.RoleOption( name='etc_hosts_entries',
+                            type=str,
+                            repr=str,
+                            inherited=True,
+                            help="Additional entries for /etc/hosts in the form "
+                                 "'foo:1.2.3.4,bar:2.3.4.5'" ) ]
+
     def other_accounts( self ):
         return super( MesosBoxSupport, self ).other_accounts( ) + [ user ]
 

--- a/spark/src/cgcloud/spark/spark_box.py
+++ b/spark/src/cgcloud/spark/spark_box.py
@@ -85,6 +85,16 @@ class SparkBox( GenericUbuntuTrustyBox, Python27UpdateUbuntuBox, ClusterBox ):
     the slaves can be started up.
     """
 
+    @classmethod
+    def get_role_options( cls ):
+        return super( SparkBox, cls ).get_role_options( ) + [
+            cls.RoleOption( name='etc_hosts_entries',
+                            type=str,
+                            repr=str,
+                            inherited=True,
+                            help="Additional entries for /etc/hosts in the form "
+                                 "'foo:1.2.3.4,bar:2.3.4.5'" ) ]
+
     def other_accounts( self ):
         return super( SparkBox, self ).other_accounts( ) + [ user ]
 


### PR DESCRIPTION
Resolves #119

```
(venv)hannes-mbpr:cgcloud hannes$ cgcloud list-options toil-box
...
etc_hosts_entries: Additional entries for /etc/hosts in the form 'foo:1.2.3.4,bar:2.3.4.5'
persist_var_lib_toil: True if /var/lib/toil should be persistent.
```

```
(venv)hannes-mbpr:cgcloud hannes$ cgcloud list-options spark-box
...
etc_hosts_entries: Additional entries for /etc/hosts in the form 'foo:1.2.3.4,bar:2.3.4.5'
```

```
(venv)hannes-mbpr:cgcloud hannes$ cgcloud list-options mesos-box
...
etc_hosts_entries: Additional entries for /etc/hosts in the form 'foo:1.2.3.4,bar:2.3.4.5'
```

Create cluster with

```
cgcloud create-cluster -O etc_hosts_entries=foo:1.2.3.4 toil
...
INFO: Run 'cgcloud ssh toil-leader' to start using this cluster.
```

Reap the benefits

```
(venv)hannes-mbpr:cgcloud hannes$ cgcloud ssh toil-leader cat /etc/hosts
...
1.2.3.4 foo
```
