### PR TITLE
Bump Spark version to 1.5.2 (resolves #118)

### DIFF
--- a/spark/src/cgcloud/spark/spark_box.py
+++ b/spark/src/cgcloud/spark/spark_box.py
@@ -35,7 +35,7 @@ hdfs_replication = 1
 
 hadoop_version = '2.6.0'
 
-spark_version = '1.2.1'
+spark_version = '1.5.2'
 
 Service = namedtuple( 'Service', [
     'init_name',
@@ -261,7 +261,7 @@ class SparkBox( GenericUbuntuTrustyBox, Python27UpdateUbuntuBox, ClusterBox ):
     @fabric_task
     def __install_spark( self ):
         # Download and extract Spark
-        path = fmt( 'spark/spark-{spark_version}/spark-{spark_version}-bin-hadoop2.4.tgz' )
+        path = fmt( 'spark/spark-{spark_version}/spark-{spark_version}-bin-hadoop2.6.tgz' )
         self.__install_apache_package( path )
 
         spark_dir = var_dir + "/spark"

--- a/spark/src/cgcloud/spark/test/test_spark.py
+++ b/spark/src/cgcloud/spark/test/test_spark.py
@@ -125,7 +125,7 @@ class SparkClusterTests( CgcloudTestCase ):
         body = dedent( '\n'.join( getsource( word_count ).split( '\n' )[ 1: ] ) )
         self._send_file( master, body, script )
 
-        self._ssh( master, 'spark-submit --executor-memory 512m ' + script )
+        self._ssh( master, 'spark-submit --driver-memory 64m --executor-memory 64m ' + script )
         self._ssh( master, 'hdfs dfs -get /test.txt.counts' )
         self._ssh( master, 'test -f test.txt.counts/_SUCCESS' )
         for i in xrange( num_slaves ):


### PR DESCRIPTION
Rebased onto master from #120

Resolves #118. Also, since Spark 1.5.2 has a binary build specific for Hadoop
2.6, I changed our link to pull that binary from the Apache mirror, as opposed
to the Hadoop 2.4 binary.
