### PR TITLE
mesos-box: Setup slaves with correct disk resources (resolves #124)

### DIFF
--- a/mesos/src/cgcloud/mesos/mesos_box.py
+++ b/mesos/src/cgcloud/mesos/mesos_box.py
@@ -55,6 +55,8 @@ mesos_services = dict(
                            '--no-switch_user',
                            '--work_dir=' + work_dir,
                            '--executor_shutdown_grace_period=60secs',
+                           "--resources=disk:$(python -c 'import os; s=os.statvfs(\"%s\"); "
+                           "f=s.f_frsize*s.f_bavail>>20; print f-min(f/2,5120)')" % work_dir,
                            '$(cat /var/lib/mesos/slave_args)' ) ] )
 
 


### PR DESCRIPTION
resolves #124

Mesos box now sets up the slave to use only the unused space on the mesos-tracked disk instead of the default - total disk.
