### PR TITLE
Add support for selecting boxes by instance ID (resolves #128)

### DIFF
--- a/core/src/cgcloud/core/commands.py
+++ b/core/src/cgcloud/core/commands.py
@@ -168,6 +168,7 @@ class InstanceCommand( BoxCommand ):
                      help=heredoc( """This option can be used to restrict the selection to boxes
                      that are part of a cluster of the given name. Boxes that are not part of a
                      cluster use their own instance id as the cluster name.""" ) )
+        self.begin_mutex()
         self.option( '--ordinal', '-o', default=-1, type=int,
                      help=heredoc( """Selects an individual box from the list of boxes performing
                      the specified role in a cluster of the given name. The ordinal is a
@@ -177,13 +178,23 @@ class InstanceCommand( BoxCommand ):
                      the ordinal is negative, it will be converted to a positive ordinal by
                      adding the number of boxes performing the specified role. Passing -1,
                      for example, selects the most recently created box.""" ) )
+        self.option( '--instance-id', '-I', default=None, type=str,
+                     help=heredoc( """Selects an individual instance. When combined with
+                     --cluster-name, the specified instance needs to belong to a cluster of the
+                     specified name or an error will be raised.""" ) )
+        self.end_mutex()
 
     wait_ready = True
 
     def run_on_box( self, options, box ):
+        if options.instance_id:
+            # Mutual exclusivity is enforced by argparse but we need to unset the default value
+            # for the mutual exclusive options.
+            options.ordinal = None
         box.bind( ordinal=options.ordinal,
                   cluster_name=options.cluster_name,
-                  wait_ready=self.wait_ready )
+                  wait_ready=self.wait_ready,
+                  instance_id=options.instance_id )
         self.run_on_instance( options, box )
 
     @abstractmethod

--- a/lib/src/cgcloud/lib/context.py
+++ b/lib/src/cgcloud/lib/context.py
@@ -402,10 +402,49 @@ class Context( object ):
             name = name[ len( self.namespace ): ]
         return name
 
+    def base_name(self,name):
+        """
+        Return the last component of a name, absolute or relative.
+
+        >>> ctx = Context( 'us-west-1b', namespace='/foo/bar/')
+        >>> ctx.base_name('')
+        ''
+        >>> ctx.base_name('/')
+        ''
+        >>> ctx.base_name('/a')
+        'a'
+        >>> ctx.base_name('/a/')
+        ''
+        >>> ctx.base_name('/a/b')
+        'b'
+        >>> ctx.base_name('/a/b/')
+        ''
+        """
+        return name.split('/')[-1]
+
     def contains_name( self, name ):
         return not self.is_absolute_name( name ) or name.startswith( self.namespace )
 
     def contains_aws_name( self, aws_name ):
+        """
+        >>> def c(n): return Context( 'us-west-1b', namespace=n)
+        >>> c('/foo/' ).contains_aws_name('bar_x')
+        False
+        >>> c('/foo/' ).contains_aws_name('foo_x')
+        True
+        >>> c('/foo/' ).contains_aws_name('foo_bar_x')
+        True
+        >>> c('/foo/' ).contains_aws_name('bar_foo_x')
+        False
+        >>> c('/' ).contains_aws_name('bar_x')
+        True
+        >>> c('/' ).contains_aws_name('foo_x')
+        True
+        >>> c('/' ).contains_aws_name('foo_bar_x')
+        True
+        >>> c('/' ).contains_aws_name('bar_foo_x')
+        True
+        """
         return self.contains_name( self.from_aws_name( aws_name ) )
 
     def try_contains_aws_name( self, aws_name ):


### PR DESCRIPTION
Add support for selecting boxes by instance ID (resolves #128)

Anywhere --ordinal is accepted, --instance-id is also accepted, but the two are mutually exclusive. If an instance ID is specified, the namespace, role name and cluster name (if given) are validated to ensure that instances aren't cross-referenced across namespaces, roles or clusters.
