### PR TITLE
toil-box: Bind mount /var/lib/toil immediately (resolves #135)

### DIFF
--- a/core/src/cgcloud/core/cluster.py
+++ b/core/src/cgcloud/core/cluster.py
@@ -86,7 +86,8 @@ class ClusterBox( Box ):
 
     def _get_instance_options( self ):
         return dict( super( ClusterBox, self )._get_instance_options( ),
-                     ebs_volume_size=str( self.ebs_volume_size ) )
+                     ebs_volume_size=str( self.ebs_volume_size ),
+                     leader_instance_id=self.instance_id)
 
     @classmethod
     def _get_node_role( cls ):
@@ -123,8 +124,7 @@ class ClusterLeader( ClusterBox ):
     A mixin for a box that serves as a leader in a cluster
     """
     def _get_instance_options( self ):
-        return dict( super( ClusterLeader, self )._get_instance_options( ),
-                     leader_instance_id=self.instance_id )
+        return dict( super( ClusterLeader, self )._get_instance_options( ) )
 
 
 class ClusterWorker( ClusterBox ):

--- a/mesos/src/cgcloud/mesos/mesos_box.py
+++ b/mesos/src/cgcloud/mesos/mesos_box.py
@@ -237,6 +237,9 @@ class MesosBoxSupport( GenericUbuntuTrustyBox, Python27UpdateUbuntuBox, CoreMeso
                 mesos_tools.stop()
                 END
                 end script""" ) )
+        # Explicitly start the mesos box services to achieve creation of lazy dirs, etc right now.
+        log.info( "Starting the mesosbox service")
+        sudo( 'initctl start mesosbox' )
 
     @fabric_task
     def _lazy_mkdir( self, parent, name, persistent=False ):


### PR DESCRIPTION
resolves #135

Currently /var/lib/toil requires a reboot for the upstart service to create and bind mount the persistent or ephemeral
directory DIR/var/lib/toil to /var/lib/toil. We now bind mount the directory at the time of creation.
