### PR TITLE
Jenkins slave slurm startup fixes

### DIFF
--- a/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
+++ b/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
@@ -307,6 +307,7 @@ class ToilJenkinsSlave( UbuntuTrustyGenericJenkinsSlave,
         sudo('/usr/sbin/service slurm-llnl start')
 
         # Ensure partition is up
+        sudo('scontrol update NodeName=localhost State=Down')
         sudo('scontrol update NodeName=localhost State=Resume')
 
     def _docker_users( self ):

--- a/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
+++ b/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
@@ -300,8 +300,14 @@ class ToilJenkinsSlave( UbuntuTrustyGenericJenkinsSlave,
         sudo('touch /var/run/slurm-llnl/slurm-acct.txt')
         sudo('chown slurm:slurm /var/run/slurm-llnl/slurm-acct.txt')
 
+        # Make sure accounting job can be read by anyone (users running sacct must have permission)
+        sudo('chmod 644 /var/run/slurm-llnl/slurm-acct.txt')
+
         # Start slurm services
         sudo('/usr/sbin/service slurm-llnl start')
+
+        # Ensure partition is up
+        sudo('scontrol update NodeName=localhost State=Resume')
 
     def _docker_users( self ):
         return super( ToilJenkinsSlave, self )._docker_users( ) + [ self.default_account( ) ]


### PR DESCRIPTION
Fixes the last two issues with the slurm installation on jenkins slave.
Ensures the accounting database can be read by all users on the box, and makes sure the partition is up.
