### PR TITLE
Install YARN on cgcloud-jenkins/toil_jenkins_slave (resolves #149, #161)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .eggs/
 nosetests.xml
 /venv/
+# emacs
+*~
+*#*

--- a/core/src/cgcloud/core/apache.py
+++ b/core/src/cgcloud/core/apache.py
@@ -1,0 +1,61 @@
+import json
+import logging
+import os
+
+from bd2k.util.strings import interpolate as fmt
+from fabric.operations import run
+
+from cgcloud.core.box import Box
+from cgcloud.fabric.operations import sudo
+
+log = logging.getLogger( __name__ )
+
+class ApacheSoftwareBox( Box ):
+    """
+    A box to be mixed in to ease the hassle of installing Apache Software
+    Foundation released software distros.
+    """
+
+    def __install_apache_package( self, path ):
+        """
+        Download the given file from an Apache download mirror.
+
+        Some mirrors may be down or serve crap, so we may need to retry this a couple of times.
+        """
+        assert path is not None
+
+        # TODO: run Fabric tasks with a different manager, so we don't need to catch SystemExit
+        components = path.split( '/' )
+        package, tarball = components[ 0 ], components[ -1 ]
+        tries = iter( xrange( 3 ) )
+        while True:
+            try:
+                mirror_url = self.__apache_s3_mirror_url( path )
+                if run( "curl -Ofs '%s'" % mirror_url, warn_only=True ).failed:
+                    mirror_url = self.__apache_official_mirror_url( path )
+                    run( "curl -Ofs '%s'" % mirror_url )
+                try:
+                    sudo( fmt( 'mkdir -p {install_dir}/{package}' ) )
+                    sudo( fmt( 'tar -C {install_dir}/{package} '
+                               '--strip-components=1 -xzf {tarball}' ) )
+                    return
+                finally:
+                    run( fmt( 'rm {tarball}' ) )
+            except SystemExit:
+                if next( tries, None ) is None:
+                    raise
+                else:
+                    log.warn( "Could not download or extract the package, retrying ..." )
+
+    # FIMXE: this might have more general utility
+
+    def __apache_official_mirror_url( self, path ):
+        mirrors = run( "curl -fs 'http://www.apache.org/dyn/closer.cgi?path=%s&asjson=1'" % path )
+        mirrors = json.loads( mirrors )
+        mirror = mirrors[ 'preferred' ]
+        url = mirror + path
+        return url
+
+    def __apache_s3_mirror_url( self, path ):
+        file_name = os.path.basename( path )
+        return 'https://s3-us-west-2.amazonaws.com/bd2k-artifacts/cgcloud/' + file_name

--- a/core/src/cgcloud/core/generic_boxes.py
+++ b/core/src/cgcloud/core/generic_boxes.py
@@ -286,4 +286,3 @@ class GenericFedora22Box( FedoraBox ):
         https://www.banym.de/linux/fedora/problems-with-missing-locale-files-on-fedora-20-made-libvirtd-service-not-starting
         """
         sudo( 'localedef -c -i en_US -f UTF-8 en_US.UTF-8' )
-

--- a/core/src/cgcloud/core/generic_boxes.py
+++ b/core/src/cgcloud/core/generic_boxes.py
@@ -286,3 +286,4 @@ class GenericFedora22Box( FedoraBox ):
         https://www.banym.de/linux/fedora/problems-with-missing-locale-files-on-fedora-20-made-libvirtd-service-not-starting
         """
         sudo( 'localedef -c -i en_US -f UTF-8 en_US.UTF-8' )
+

--- a/core/src/cgcloud/core/rc_local_box.py
+++ b/core/src/cgcloud/core/rc_local_box.py
@@ -75,11 +75,17 @@ class RcLocalBox( Box ):
         env_file.seek( 0 )
         env = dict( parse_entry( _ ) for _ in env_file.read( ).splitlines( ) )
 
-        # do we have dirs to add to the path
+        # do we have dirs to add to a path
         if not dirs is None:
-            path = env[ 'PATH' ].split( ':' )
+            
+            # if envar is default (None), set to PATH
+            # else, the user is adding to a different path
+            if envar is None:
+                envar = 'PATH'
+
+            path = env[ envar ].split( ':' )
             path.extend( dirs )
-            env[ 'PATH' ] = ':'.join( path )
+            env[ envar ] = ':'.join( path )
 
         # do we have environment variables to write?
         if not env_pairs is None:


### PR DESCRIPTION
Resolves #149, #161 

Installs Apache Hadoop 2.6.2 on the toil_jenkins_slave image by pulling down the prebuilt artifacts from an Apache mirror. YARN is a subcomponent of Hadoop. This does not start the YARN nodemanager/resourcemanager, as they are started downstream in the toil test suites.

Also see https://github.com/BD2KGenomics/toil/issues/796.

Still WIP. A quick question: I need to set the `HADOOP_HOME` environment variable. Is the best way to do this to cat to `~/.profile`? I know that I can use the fabric context manager utilities to set an envar when using fabric, but I need this environment variable to be set for the YARN tests in toil to run. Otherwise, I also need to modify a Hadoop config file; I will add that soon.
