### PR TITLE
Add --vpc and --subnet to `cgcloud create` (resolves #163)

### DIFF
--- a/core/src/cgcloud/core/commands.py
+++ b/core/src/cgcloud/core/commands.py
@@ -454,6 +454,22 @@ class CreationCommand( BoxCommand ):
                      accepted. By default on-demand instances are used. Note that some instance
                      types are not available on the spot market!""" ) )
 
+        self.option( '--vpc', metavar='VPC_ID', type=str, dest='vpc_id',
+                     help=heredoc( """The ID of a VPC to create the instance and associated 
+                     security group in. If this option is absent and the AWS account has a 
+                     default VPC, the default VPC will be used. This is the most common case. If 
+                     this option is absent and the AWS account has EC2 Classic enabled and the 
+                     selected instance type supports EC2 classic mode, no VPC will be used. If 
+                     this option is absent and the AWS account has no default VPC and an instance 
+                     type that only supports VPC is used, an exception will be raised.""" ) )
+
+        self.option( '--subnet', metavar='SUBNET_ID', type=str, dest='subnet_id',
+                     help=heredoc( """The ID of a subnet to allocate the instance's private IP 
+                     address from. Can't be combined with --spot-auto-zone. The specified subnet 
+                     must belong to the specified VPC (or the default VPC if none was given) and 
+                     reside in the availability zone given via CGCLOUD_ZONE or --zone. If this 
+                     option is absent, cgcloud will attempt to choose a subnet automatically.""" ) ) 
+
         self.option( '--spot-launch-group', metavar='NAME',
                      help=heredoc( """The name of an EC2 spot instance launch group. If
                      specified, the spot request will only be fullfilled once all instances in
@@ -529,6 +545,8 @@ class CreationCommand( BoxCommand ):
                      ec2_keypair_globs=map( resolve_me, options.ec2_keypair_names ),
                      instance_type=options.instance_type,
                      virtualization_type=options.virtualization_type,
+                     vpc_id=options.vpc_id,
+                     subnet_id=options.subnet_id,
                      spot_bid=options.spot_bid,
                      spot_launch_group=options.spot_launch_group,
                      spot_auto_zone=options.spot_auto_zone )

--- a/lib/src/cgcloud/lib/context.py
+++ b/lib/src/cgcloud/lib/context.py
@@ -123,11 +123,10 @@ class Context( object ):
         super( Context, self ).__init__( )
 
         self.__iam = None
-        self.__ec2 = None
+        self.__vpc = None
         self.__s3 = None
         self.__sns = None
         self.__sqs = None
-        self.__vpc = None
 
         self.availability_zone = availability_zone
         m = self.availability_zone_re.match( availability_zone )
@@ -159,14 +158,7 @@ class Context( object ):
             self.__iam = self.__aws_connect( iam, 'universal' )
         return self.__iam
 
-    @property
-    def ec2( self ):
-        """
-        :rtype: EC2Connection
-        """
-        if self.__ec2 is None:
-            self.__ec2 = self.__aws_connect( ec2 )
-        return self.__ec2
+    # VPCConnection extends EC2Connection so we can use one instance of the former for both 
 
     @property
     def vpc( self ):
@@ -176,6 +168,8 @@ class Context( object ):
         if self.__vpc is None:
             self.__vpc = self.__aws_connect( vpc )
         return self.__vpc
+
+    ec2 = vpc
 
     @property
     def s3( self ):
@@ -223,7 +217,7 @@ class Context( object ):
         self.close( )
 
     def close( self ):
-        if self.__ec2 is not None: self.__ec2.close( )
+        if self.__vpc is not None: self.__vpc.close( )
         if self.__s3 is not None: self.__s3.close( )
         if self.__iam is not None: self.__iam.close( )
         if self.__sns is not None: self.__sns.close( )


### PR DESCRIPTION
… so cgcloud can be used in pre-2013 AWS accounts where no default VPC exists.

Resolves #163
