### PR TITLE
Downgrade Toil Jenkins worker to Spark 1.5.2 (resolves #189)

### DIFF
--- a/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
+++ b/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
@@ -19,7 +19,7 @@ from cgcloud.lib.util import abreviated_snake_case_class_name, heredoc
 hadoop_version = '2.6.2'
 # The major version of Hadoop that the Spark binaries were built against 
 spark_hadoop_version = '2.6'
-spark_version = '1.6.1'
+spark_version = '1.5.2'
 install_dir = '/opt'
 
 class ToilJenkinsSlave( UbuntuTrustyGenericJenkinsSlave,


### PR DESCRIPTION
Downgrades the Toil Jenkins test worker to Spark 1.5.2, which is the same version as the Docker image that we use for Apache Spark. If the two versions are different, then the Toil unittests may not be able to connect to the Spark cluster we've spawned. Specifically, the driver<->leader wire protocol is subject to change between different Spark major versions.

It turned out that the SPARK_HOME environment variable was already set, so I did not need to change anything there.
