### PR TITLE
Bump ToilBox to Toil 3.2.0 (resolves #192)

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -27,5 +27,6 @@ setup( name='cgcloud-core',
                           'paramiko==1.16.0',
                           'futures==3.0.4',
                           'PyYAML==3.11',
-                          'subprocess32==3.2.7' ],
+                          'subprocess32==3.2.7',
+                          'tabulate==0.7.5'],
        test_suite='cgcloud.core.test' )

--- a/core/src/cgcloud/core/commands.py
+++ b/core/src/cgcloud/core/commands.py
@@ -1,24 +1,28 @@
 from __future__ import print_function
-from abc import abstractmethod
+
 import argparse
 import functools
 import logging
-from operator import itemgetter
 import os
 import re
 import sys
+from abc import abstractmethod
+from operator import itemgetter
+
 from bd2k.util.exceptions import panic
 from bd2k.util.expando import Expando
 from bd2k.util.iterables import concat
-from boto.ec2.connection import EC2Connection
 from boto.ec2.blockdevicemapping import BlockDeviceType
+from boto.ec2.connection import EC2Connection
 from boto.ec2.group import Group
 from fabric.operations import prompt
+from tabulate import tabulate
+
+from cgcloud.core.box import Box
+from cgcloud.lib.context import Context
 from cgcloud.lib.ec2 import ec2_instance_types
 from cgcloud.lib.util import Application, heredoc
-from cgcloud.lib.context import Context
 from cgcloud.lib.util import UserError, Command
-from cgcloud.core.box import Box
 
 log = logging.getLogger( __name__ )
 
@@ -642,7 +646,8 @@ class ListRolesCommand( Command ):
     """
 
     def run( self, options ):
-        print( '\n'.join( self.application.roles.iterkeys( ) ) )
+        print( tabulate( (name , (role.__doc__ or '').strip().split('\n')[0].strip())
+                         for name, role in self.application.roles.iteritems( ) ) )
         log.info( "If you are expecting to see more roles listed above, you may need to set/change "
                   "the CGCLOUD_PLUGINS environment variable." )
 

--- a/core/src/cgcloud/core/generic_boxes.py
+++ b/core/src/cgcloud/core/generic_boxes.py
@@ -86,7 +86,7 @@ class GenericCentos5Box( CentosBox ):
 
 class GenericCentos6Box( CentosBox ):
     """
-    The slightly newer CentOS 6 from 1999 ;-)
+    Generic box with Centos 6.4
     """
 
     def release( self ):
@@ -166,6 +166,9 @@ class GenericUbuntuOneiricBox( UpstartUbuntuBox ):
 
 
 class GenericUbuntuPreciseBox( UpstartUbuntuBox ):
+    """
+    Generic box with Ubuntu 12.04 LTS (EOL April 2017)
+    """
     def release( self ):
         return self.Release( codename='precise', version='12.04' )
 
@@ -189,6 +192,9 @@ class GenericUbuntuSaucyBox( UpstartUbuntuBox ):
 
 
 class GenericUbuntuTrustyBox( UpstartUbuntuBox ):
+    """
+    Generic box with Ubuntu 14.04 LTS (EOL April 2019)
+    """
     def release( self ):
         return self.Release( codename='trusty', version='14.04' )
 
@@ -200,6 +206,9 @@ class GenericUbuntuUtopicBox( UpstartUbuntuBox ):
 
 
 class GenericUbuntuVividBox( SystemdUbuntuBox ):
+    """
+    Generic box with Ubuntu 15.04 (EOL February 4, 2016)
+    """
     def release( self ):
         return self.Release( codename='vivid', version='15.04' )
 
@@ -263,11 +272,17 @@ class GenericFedora20Box( FedoraBox ):
 
 
 class GenericFedora21Box( FedoraBox ):
+    """
+    Generic box with Fedora 21
+    """
     def release( self ):
         return 21
 
 
 class GenericFedora22Box( FedoraBox ):
+    """
+    Generic box with Fedora 22
+    """
     def release( self ):
         return 22
 

--- a/jenkins/src/cgcloud/jenkins/cgcloud_jenkins_slave.py
+++ b/jenkins/src/cgcloud/jenkins/cgcloud_jenkins_slave.py
@@ -8,7 +8,7 @@ from cgcloud.jenkins.generic_jenkins_slaves import UbuntuTrustyGenericJenkinsSla
 
 class CgcloudJenkinsSlave( UbuntuTrustyGenericJenkinsSlave, Python27UpdateUbuntuBox ):
     """
-    A Jenkins slave for runing CGCloud's unit tests
+    Jenkins slave for runing CGCloud's unit tests
     """
 
     @classmethod

--- a/jenkins/src/cgcloud/jenkins/generic_jenkins_slaves.py
+++ b/jenkins/src/cgcloud/jenkins/generic_jenkins_slaves.py
@@ -7,14 +7,14 @@ from cgcloud.core.ubuntu_box import UbuntuBox
 
 class GenericJenkinsSlave( JenkinsSlave ):
     """
-    A generic Jenkins slave
+    Generic Jenkins slave
     """
     pass
 
 
 class CentosGenericJenkinsSlave( CentosBox, GenericJenkinsSlave ):
     """
-    A generic Jenkins slave for CentOS
+    Generic Jenkins slave for CentOS
     """
 
     def _list_packages_to_install( self ):
@@ -41,21 +41,21 @@ class CentosGenericJenkinsSlave( CentosBox, GenericJenkinsSlave ):
 
 class Centos5GenericJenkinsSlave( CentosGenericJenkinsSlave, GenericCentos5Box ):
     """
-    A generic Jenkins slave for CentOS 5
+    Generic Jenkins slave for CentOS 5
     """
     pass
 
 
 class Centos6GenericJenkinsSlave( CentosGenericJenkinsSlave, GenericCentos6Box ):
     """
-    A generic Jenkins slave for CentOS 6
+    Generic Jenkins slave for CentOS 6
     """
     pass
 
 
 class UbuntuGenericJenkinsSlave( UbuntuBox, GenericJenkinsSlave ):
     """
-    A generic Jenkins slave for Ubuntu
+    Generic Jenkins slave for Ubuntu
     """
 
     def _list_packages_to_install( self ):
@@ -81,7 +81,7 @@ class UbuntuGenericJenkinsSlave( UbuntuBox, GenericJenkinsSlave ):
 
 class UbuntuLucidGenericJenkinsSlave( UbuntuGenericJenkinsSlave, GenericUbuntuLucidBox ):
     """
-    A generic Jenkins slave for Ubuntu 10.04 LTS (EOL April 2015)
+    Generic Jenkins slave for Ubuntu 10.04 LTS (EOL April 2015)
     """
 
     def _setup_package_repos( self ):
@@ -110,21 +110,21 @@ class UbuntuLucidGenericJenkinsSlave( UbuntuGenericJenkinsSlave, GenericUbuntuLu
 
 class UbuntuPreciseGenericJenkinsSlave( UbuntuGenericJenkinsSlave, GenericUbuntuPreciseBox ):
     """
-    A generic Jenkins slave for Ubuntu 12.04 LTS (EOL April 2017)
+    Generic Jenkins slave for Ubuntu 12.04 LTS (EOL April 2017)
     """
     pass
 
 
 class UbuntuTrustyGenericJenkinsSlave( UbuntuGenericJenkinsSlave, GenericUbuntuTrustyBox ):
     """
-    A generic Jenkins slave for Ubuntu 14.04 LTS (EOL April 2019)
+    Generic Jenkins slave for Ubuntu 14.04 LTS (EOL April 2019)
     """
     pass
 
 
 class FedoraGenericJenkinsSlave( FedoraBox, GenericJenkinsSlave ):
     """
-    A generic Jenkins slave for Fedora
+    Generic Jenkins slave for Fedora
     """
 
     def _list_packages_to_install( self ):
@@ -141,13 +141,13 @@ class FedoraGenericJenkinsSlave( FedoraBox, GenericJenkinsSlave ):
 
 class Fedora19GenericJenkinsSlave( FedoraGenericJenkinsSlave, GenericFedora19Box ):
     """
-    A generic Jenkins slave for Fedora 19
+    Generic Jenkins slave for Fedora 19
     """
     pass
 
 
 class Fedora20GenericJenkinsSlave( FedoraGenericJenkinsSlave, GenericFedora20Box ):
     """
-    A generic Jenkins slave for Fedora 20
+    Generic Jenkins slave for Fedora 20
     """
     pass

--- a/jenkins/src/cgcloud/jenkins/rpmbuild_jenkins_slaves.py
+++ b/jenkins/src/cgcloud/jenkins/rpmbuild_jenkins_slaves.py
@@ -8,7 +8,7 @@ from cgcloud.jenkins.jenkins_slave import JenkinsSlave
 
 class CentosRpmbuildJenkinsSlave( CentosBox, JenkinsSlave ):
     """
-    A Jenkins slave for building RPMs on CentOS
+    Jenkins slave for building RPMs on CentOS
     """
 
     def _list_packages_to_install(self):
@@ -44,7 +44,13 @@ class CentosRpmbuildJenkinsSlave( CentosBox, JenkinsSlave ):
 
 
 class Centos5RpmbuildJenkinsSlave(CentosRpmbuildJenkinsSlave, GenericCentos5Box):
+    """
+    Jenkins slave for building RPMs on CentOS 5
+    """
     pass
 
 class Centos6RpmbuildJenkinsSlave(CentosRpmbuildJenkinsSlave, GenericCentos6Box):
+    """
+    Jenkins slave for building RPMs on CentOS 6
+    """
     pass

--- a/jenkins/src/cgcloud/jenkins/s3am_jenkins_slave.py
+++ b/jenkins/src/cgcloud/jenkins/s3am_jenkins_slave.py
@@ -8,7 +8,7 @@ from cgcloud.lib.util import abreviated_snake_case_class_name, heredoc
 
 class S3amJenkinsSlave( UbuntuTrustyGenericJenkinsSlave, Python27UpdateUbuntuBox ):
     """
-    A Jenkins slave for running the S3AM build
+    Jenkins slave for running the S3AM build
     """
 
     @classmethod

--- a/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
+++ b/jenkins/src/cgcloud/jenkins/toil_jenkins_slave.py
@@ -28,8 +28,7 @@ class ToilJenkinsSlave( UbuntuTrustyGenericJenkinsSlave,
                         MesosBox,
                         ApacheSoftwareBox ):
     """
-    A Jenkins slave suitable for running Toil unit tests, specifically the Mesos batch system and
-    the AWS job store. Legacy batch systems (parasol, gridengine, ...) are not yet supported.
+    Jenkins slave for running the Toil build and tests on
     """
 
     @classmethod

--- a/mesos/src/cgcloud/mesos/mesos_box.py
+++ b/mesos/src/cgcloud/mesos/mesos_box.py
@@ -289,12 +289,21 @@ class MesosBoxSupport( GenericUbuntuTrustyBox, Python27UpdateUbuntuBox, CoreMeso
 
 
 class MesosBox( MesosBoxSupport, ClusterBox ):
+    """
+    A node in a Mesos cluster; used only to create an image for master and worker boxes
+    """
     pass
 
 
 class MesosMaster( MesosBox, ClusterLeader ):
+    """
+    The master of a cluster of boxes created from a mesos-box image
+    """
     pass
 
 
 class MesosSlave( MesosBox, ClusterWorker ):
+    """
+    A slave in a cluster of boxes created from a mesos-box image
+    """
     pass

--- a/spark/src/cgcloud/spark/spark_box.py
+++ b/spark/src/cgcloud/spark/spark_box.py
@@ -74,11 +74,12 @@ class SparkBox( ApacheSoftwareBox,
                 GenericUbuntuTrustyBox,
                 Python27UpdateUbuntuBox ):
     """
-    A node in a Spark cluster. Workers and the master undergo the same setup. Whether a node acts
-    as a master or a slave is determined at boot time, via user data. All slave nodes will be
-    passed the IP of the master node. This implies that the master is started first. As soon as
-    its private IP is assigned, typically seconds after the reservation has been submitted,
-    the slaves can be started up.
+    A node in a Spark cluster; used only to create an image for master and worker boxes
+
+    Workers and the master undergo the same setup. Whether a node acts as a master or a slave is
+    determined at boot time, via user data. All slave nodes will be passed the IP of the master
+    node. This implies that the master is started first. As soon as its private IP is assigned,
+    typically seconds after the reservation has been submitted, the slaves can be started up.
     """
 
     @classmethod
@@ -431,8 +432,14 @@ class SparkBox( ApacheSoftwareBox,
 
 
 class SparkMaster( SparkBox, ClusterLeader ):
+    """
+    The master of a cluster of boxes created from a spark-box image
+    """
     pass
 
 
 class SparkSlave( SparkBox, ClusterWorker ):
+    """
+    A slave in a cluster of boxes created from a spark-box image
+    """
     pass

--- a/toil/src/cgcloud/toil/__init__.py
+++ b/toil/src/cgcloud/toil/__init__.py
@@ -1,5 +1,9 @@
 def roles( ):
-    from cgcloud.toil.toil_box import (ToilBox, ToilLatestBox, ToilLeader, ToilWorker)
+    from cgcloud.toil.toil_box import (ToilLegacyBox,
+                                       ToilBox,
+                                       ToilLatestBox,
+                                       ToilLeader,
+                                       ToilWorker)
     return sorted( locals( ).values( ), key=lambda cls: cls.__name__ )
 
 

--- a/toil/src/cgcloud/toil/toil_box.py
+++ b/toil/src/cgcloud/toil/toil_box.py
@@ -124,7 +124,7 @@ class ToilBox( ToilBoxSupport ):
     A box with Mesos, Toil 3.2.0 and their dependencies installed.
     """
 
-    default_spec = 'toil[aws,mesos,encryption,cwl,cgcloud]==3.2.1'
+    default_spec = 'toil[aws,mesos,encryption,cwl]==3.2.1'
 
     @classmethod
     def get_role_options( cls ):

--- a/toil/src/cgcloud/toil/toil_box.py
+++ b/toil/src/cgcloud/toil/toil_box.py
@@ -123,7 +123,7 @@ class ToilBox( ToilBoxSupport ):
     A box with Mesos, Toil 3.2.0 and their dependencies installed.
     """
 
-    default_spec = 'toil[aws,mesos,encryption,cwl,cgcloud]==3.2.0'
+    default_spec = 'toil[aws,mesos,encryption,cwl,cgcloud]==3.2.1'
 
     @classmethod
     def get_role_options( cls ):

--- a/toil/src/cgcloud/toil/toil_box.py
+++ b/toil/src/cgcloud/toil/toil_box.py
@@ -77,7 +77,8 @@ class ToilBoxSupport( MesosBoxSupport, DockerBox, ClusterBox ):
 
     def _get_iam_ec2_role( self ):
         role_name, policies = super( ToilBoxSupport, self )._get_iam_ec2_role( )
-        role_name += '--' + abreviated_snake_case_class_name( ToilBoxSupport )
+        # Cheating with the name here. ToilBoxSupport was pushing it beyond the 64 character limit.
+        role_name += '--' + abreviated_snake_case_class_name( ToilBox )
         policies.update( dict(
             ec2_full=ec2_full_policy,
             s3_full=s3_full_policy,

--- a/toil/src/cgcloud/toil/toil_box.py
+++ b/toil/src/cgcloud/toil/toil_box.py
@@ -2,6 +2,8 @@ import logging
 import os
 
 import re
+from abc import abstractmethod
+
 from bd2k.util import strict_bool
 from bd2k.util.iterables import concat
 from fabric.operations import put
@@ -18,33 +20,33 @@ from cgcloud.mesos.mesos_box import MesosBoxSupport, user, persistent_dir
 log = logging.getLogger( __name__ )
 
 
-class ToilBox( MesosBoxSupport, DockerBox, ClusterBox ):
+class ToilBoxSupport( MesosBoxSupport, DockerBox, ClusterBox ):
     """
     A box with Mesos, Toil and their dependencies installed.
     """
 
     def _list_packages_to_install( self ):
-        return super( ToilBox, self )._list_packages_to_install( ) + [
+        return super( ToilBoxSupport, self )._list_packages_to_install( ) + [
             'python-dev', 'gcc', 'make',
             'libcurl4-openssl-dev',  # Only for S3AM
             'libffi-dev' ]  # pynacl -> toil, Azure client-side encryption
 
     def _post_install_mesos( self ):
-        super( ToilBox, self )._post_install_mesos( )
+        super( ToilBoxSupport, self )._post_install_mesos( )
         # Override this method instead of _post_install_packages() such that this is run before
         self.__install_toil( )
         self.__install_s3am( )
 
     def _docker_users( self ):
-        return super( ToilBox, self )._docker_users( ) + [ user ]
+        return super( ToilBoxSupport, self )._docker_users( ) + [ user ]
 
     def _docker_data_prefixes( self ):
         # We prefer Docker to be stored on the persistent volume if there is one
-        return concat( persistent_dir, super( ToilBox, self )._docker_data_prefixes( ) )
+        return concat( persistent_dir, super( ToilBoxSupport, self )._docker_data_prefixes( ) )
 
     @fabric_task
     def _setup_docker( self ):
-        super( ToilBox, self )._setup_docker( )
+        super( ToilBoxSupport, self )._setup_docker( )
         # The docker and dockerbox init jobs depend on /mnt/persistent which is set up by the
         # mesosbox job. Adding a dependency of the docker job on mesosbox should satsify that
         # dependency.
@@ -66,7 +68,7 @@ class ToilBox( MesosBoxSupport, DockerBox, ClusterBox ):
 
     @classmethod
     def get_role_options( cls ):
-        return super( ToilBox, cls ).get_role_options( ) + [
+        return super( ToilBoxSupport, cls ).get_role_options( ) + [
             cls.RoleOption( name='persist_var_lib_toil',
                             type=strict_bool,
                             repr=repr,
@@ -74,8 +76,8 @@ class ToilBox( MesosBoxSupport, DockerBox, ClusterBox ):
                             help='True if /var/lib/toil should be persistent.' ) ]
 
     def _get_iam_ec2_role( self ):
-        role_name, policies = super( ToilBox, self )._get_iam_ec2_role( )
-        role_name += '--' + abreviated_snake_case_class_name( ToilBox )
+        role_name, policies = super( ToilBoxSupport, self )._get_iam_ec2_role( )
+        role_name += '--' + abreviated_snake_case_class_name( ToilBoxSupport )
         policies.update( dict(
             ec2_full=ec2_full_policy,
             s3_full=s3_full_policy,
@@ -85,6 +87,10 @@ class ToilBox( MesosBoxSupport, DockerBox, ClusterBox ):
                 dict( Effect="Allow", Resource="*", Action="ec2:CreateVolume" ),
                 dict( Effect="Allow", Resource="*", Action="ec2:AttachVolume" ) ] ) ) )
         return role_name, policies
+
+    @abstractmethod
+    def _toil_pip_args( self ):
+        raise NotImplementedError()
 
     @fabric_task
     def __install_toil( self ):
@@ -102,16 +108,26 @@ class ToilBox( MesosBoxSupport, DockerBox, ClusterBox ):
                     pip_distribution='pip==8.0.2',
                     executable='s3am' )
 
+
+class ToilLegacyBox( ToilBoxSupport ):
+    """
+    A box with Mesos, Toil 3.1.6 and their dependencies installed.
+    """
+
     def _toil_pip_args( self ):
         return [ 'toil[aws,mesos,encryption]==3.1.6' ]
 
 
-class ToilLatestBox( ToilBox ):
-    default_spec = 'toil[aws,mesos,encryption,cwl,cgcloud]<=3.2.0'
+class ToilBox( ToilBoxSupport ):
+    """
+    A box with Mesos, Toil 3.2.0 and their dependencies installed.
+    """
+
+    default_spec = 'toil[aws,mesos,encryption,cwl,cgcloud]==3.2.0'
 
     @classmethod
     def get_role_options( cls ):
-        return super( ToilLatestBox, cls ).get_role_options( ) + [
+        return super( ToilBox, cls ).get_role_options( ) + [
             cls.RoleOption( name='toil_sdists',
                             type=cls.parse_sdists,
                             repr=cls.unparse_sdists,
@@ -155,9 +171,22 @@ class ToilLatestBox( ToilBox ):
             return [ '--pre', self.default_spec ]
 
 
+class ToilLatestBox( ToilBox ):
+    """
+    A box with Mesos, the latest unstable release of Toil and their dependencies installed
+    """
+    default_spec = 'toil[aws,mesos,encryption,cwl,cgcloud]<=3.3.0'
+
+
 class ToilLeader( ToilBox, ClusterLeader ):
+    """
+    Leader of a cluster of boxes booted from a toil-box, toil-latest-box or toil-legacy-box image
+    """
     pass
 
 
 class ToilWorker( ToilBox, ClusterWorker ):
+    """
+    Worker in a cluster of boxes booted from a toil-box, toil-latest-box or toil-legacy-box image
+    """
     pass


### PR DESCRIPTION
ToilBox is now ToilLegacyBox, ToilLatestBox is now ToilBox, ToilLatestBox added back for Toil 3.3.0 pre-releases.

Added descriptions to role listings; use tabulate to improve it. This should reduce the confusion as to which Toil role installs which Toil release, especially since ToilBox in the 1.4.0 release installs Toil 3.1.6 while the 1.5.0 pre-release installs 3.2.0.

The descriptions are derived from the first line in each role's docstring.
