### PR TITLE
Bump toil-latest-box to install pre-releases of Toil up to 3.5.0 (fixes #239)

### DIFF
--- a/toil/src/cgcloud/toil/toil_box.py
+++ b/toil/src/cgcloud/toil/toil_box.py
@@ -179,7 +179,7 @@ class ToilLatestBox( ToilBox ):
     """
     A box with Mesos, the latest unstable release of Toil and their dependencies installed
     """
-    default_spec = 'toil[aws,mesos,encryption,cwl]<=3.6.0'
+    default_spec = 'toil[aws,mesos,encryption,cwl]<=3.5.0'
 
 
 class ToilLeader( ToilBox, ClusterLeader ):


### PR DESCRIPTION
fixes #239 on master